### PR TITLE
fix(#15): Ignore own zip file for zipping

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,9 @@ func Execute() {
 	errCheck(err, c)
 
 	for _, f := range *features.Features() {
+		// Clean paths before each feature to take that logic off the features
+		c.CleanPaths()
+
 		if f.IsEnabled(c) {
 			output.Debugf("Executing feature %s ...", f.DebugName())
 			errCheck(f.Execute(c), c)

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	flag "github.com/spf13/pflag"
+	"path/filepath"
 )
 
 // ErrMinimalParamsMissing states that the minimal arguments for the tool are not present, making it unprocessable
@@ -79,8 +80,19 @@ func (conf *Configuration) parseVarargs() error {
 	}
 
 	conf.ZipFile = remaining[0]
+
 	conf.SourceFiles = remaining[1:]
+
 	return nil
+}
+
+// CleanPaths ensure that all directories and files in the file set have clean path names
+func (conf *Configuration) CleanPaths() {
+	cleaned := make([]string, 0, len(conf.SourceFiles))
+	for _, f := range conf.SourceFiles {
+		cleaned = append(cleaned, filepath.Clean(f))
+	}
+	conf.SourceFiles = cleaned
 }
 
 func (conf *Configuration) Help() {

--- a/pkg/features/fileset/directories_test.go
+++ b/pkg/features/fileset/directories_test.go
@@ -14,6 +14,10 @@ func TestDirectoriesIsEnabled(t *testing.T) {
 	}
 }
 
+func TestDirectoriesDebugName(t *testing.T) {
+	testDebugName(t, (Directories{}).DebugName(), "Directories")
+}
+
 func TestDirectoriesExecute(t *testing.T) {
 	directories := Directories{}
 	testCases := []struct {

--- a/pkg/features/fileset/directories_test.go
+++ b/pkg/features/fileset/directories_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestDirectoriesIsEnabled(t *testing.T) {
+func TestDirectories_IsEnabled(t *testing.T) {
 	c := cli.Configuration{Directories: true}
 	directories := Directories{}
 	if !directories.IsEnabled(&c) {
@@ -14,11 +14,11 @@ func TestDirectoriesIsEnabled(t *testing.T) {
 	}
 }
 
-func TestDirectoriesDebugName(t *testing.T) {
+func TestDirectories_DebugName(t *testing.T) {
 	testDebugName(t, (Directories{}).DebugName(), "Directories")
 }
 
-func TestDirectoriesExecute(t *testing.T) {
+func TestDirectories_Execute(t *testing.T) {
 	directories := Directories{}
 	testCases := []struct {
 		sources      []string

--- a/pkg/features/fileset/ignore-target-zip.go
+++ b/pkg/features/fileset/ignore-target-zip.go
@@ -1,0 +1,31 @@
+package fileset
+
+import (
+	"github.com/timo-reymann/deterministic-zip/pkg/cli"
+	"path/filepath"
+)
+
+// IgnoreTargetZip removes the zip file from the file set if found
+type IgnoreTargetZip struct{}
+
+func (i IgnoreTargetZip) DebugName() string {
+	return "IgnoreTargetZip (builtin)"
+}
+
+// IsEnabled always returns true as this feature is a safety mechanism
+func (i IgnoreTargetZip) IsEnabled(c *cli.Configuration) bool {
+	return true
+}
+
+// Execute removes the target zip file if it finds it in the fileset list and exits
+func (i IgnoreTargetZip) Execute(c *cli.Configuration) error {
+	target := filepath.Clean(c.ZipFile)
+
+	for idx, f := range c.SourceFiles {
+		if target == f {
+			c.SourceFiles = append(c.SourceFiles[:idx], c.SourceFiles[idx+1:]...)
+			break
+		}
+	}
+	return nil
+}

--- a/pkg/features/fileset/ignore-target-zip_test.go
+++ b/pkg/features/fileset/ignore-target-zip_test.go
@@ -1,0 +1,82 @@
+package fileset
+
+import (
+	"github.com/timo-reymann/deterministic-zip/pkg/cli"
+	"reflect"
+	"testing"
+)
+
+func TestIgnoreTargetZipIsEnabled(t *testing.T) {
+	ignoreZip := IgnoreTargetZip{}
+	if !ignoreZip.IsEnabled(&cli.Configuration{}) {
+		t.Fatal("The feature should be enabled by default")
+	}
+}
+
+func TestIgnoreTargetZipDebugName(t *testing.T) {
+	testDebugName(t, (IgnoreTargetZip{}).DebugName(), "IgnoreTargetZip (builtin)")
+}
+
+func TestIgnoreTargetZipExecute(t *testing.T) {
+	ignoreZip := IgnoreTargetZip{}
+
+	testCases := []struct {
+		sources      []string
+		zipFile      string
+		err          *error
+		sourcesAfter []string
+	}{
+		{
+			zipFile: "test.zip",
+			sources: []string{
+				"testdata",
+				"test.zip",
+			},
+			err: nil,
+			sourcesAfter: []string{
+				"testdata",
+			},
+		},
+		{
+			zipFile: "test.zip",
+			sources: []string{
+				"testdata",
+				"test.zip",
+				"archive.zip",
+			},
+			err: nil,
+			sourcesAfter: []string{
+				"testdata",
+				"archive.zip",
+			},
+		},
+		{
+			zipFile: "test.zip",
+			sources: []string{
+				"testdata",
+				"test.zip",
+				"folder/test.zip",
+			},
+			err: nil,
+			sourcesAfter: []string{
+				"testdata",
+				"folder/test.zip",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		c := cli.Configuration{
+			ZipFile:     tc.zipFile,
+			SourceFiles: tc.sources,
+		}
+		err := ignoreZip.Execute(&c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(tc.sourcesAfter, c.SourceFiles) {
+			t.Fatalf("Expected %v, but got %v", tc.sourcesAfter, c.SourceFiles)
+		}
+	}
+}

--- a/pkg/features/fileset/ignore-target-zip_test.go
+++ b/pkg/features/fileset/ignore-target-zip_test.go
@@ -6,18 +6,18 @@ import (
 	"testing"
 )
 
-func TestIgnoreTargetZipIsEnabled(t *testing.T) {
+func TestIgnoreTargetZip_IsEnabled(t *testing.T) {
 	ignoreZip := IgnoreTargetZip{}
 	if !ignoreZip.IsEnabled(&cli.Configuration{}) {
 		t.Fatal("The feature should be enabled by default")
 	}
 }
 
-func TestIgnoreTargetZipDebugName(t *testing.T) {
+func TestIgnoreTargetZip_DebugName(t *testing.T) {
 	testDebugName(t, (IgnoreTargetZip{}).DebugName(), "IgnoreTargetZip (builtin)")
 }
 
-func TestIgnoreTargetZipExecute(t *testing.T) {
+func TestIgnoreTargetZip_Execute(t *testing.T) {
 	ignoreZip := IgnoreTargetZip{}
 
 	testCases := []struct {

--- a/pkg/features/fileset/recursive_test.go
+++ b/pkg/features/fileset/recursive_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestRecursiveIsEnabled(t *testing.T) {
+func TestRecursive_IsEnabled(t *testing.T) {
 	c := cli.Configuration{Recursive: true}
 	recursive := Recursive{}
 	if !recursive.IsEnabled(&c) {
@@ -15,7 +15,7 @@ func TestRecursiveIsEnabled(t *testing.T) {
 	}
 }
 
-func TestRecursiveDebugName(t *testing.T) {
+func TestRecursive_DebugName(t *testing.T) {
 	testDebugName(t, (Recursive{}).DebugName(), "Recursive")
 }
 
@@ -24,7 +24,7 @@ func mockErr(msg string) *error {
 	return &err
 }
 
-func TestRecursiveExecute(t *testing.T) {
+func TestRecursive_Execute(t *testing.T) {
 	recursive := Recursive{}
 	testCases := []struct {
 		sources      []string
@@ -79,11 +79,9 @@ func TestRecursiveExecute(t *testing.T) {
 		err := recursive.Execute(&c)
 		if tc.err == nil && err != nil {
 			t.Fatalf("Expected no error but got %v", err)
-			t.FailNow()
 		} else if err != nil {
 			if (*tc.err).Error() != err.Error() {
 				t.Fatalf("Expected error %v, but got %v", *tc.err, err)
-				t.FailNow()
 			} else {
 				// Skip checking -> error thrown
 				continue

--- a/pkg/features/fileset/recursive_test.go
+++ b/pkg/features/fileset/recursive_test.go
@@ -15,6 +15,10 @@ func TestRecursiveIsEnabled(t *testing.T) {
 	}
 }
 
+func TestRecursiveDebugName(t *testing.T) {
+	testDebugName(t, (Recursive{}).DebugName(), "Recursive")
+}
+
 func mockErr(msg string) *error {
 	err := errors.New(msg)
 	return &err

--- a/pkg/features/fileset/util_test.go
+++ b/pkg/features/fileset/util_test.go
@@ -1,0 +1,11 @@
+package fileset
+
+import (
+	"testing"
+)
+
+func testDebugName(t *testing.T, actual string, expected string) {
+	if actual != expected {
+		t.Fatalf("Expected debug name to be '%s' but got '%s' instead", expected, actual)
+	}
+}

--- a/pkg/features/filter/exclude_test.go
+++ b/pkg/features/filter/exclude_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestExcludeIsEnabled(t *testing.T) {
+func TestExclude_IsEnabled(t *testing.T) {
 	config := cli.Configuration{Exclude: []string{
 		"foo.*",
 	}}
@@ -16,11 +16,11 @@ func TestExcludeIsEnabled(t *testing.T) {
 	}
 }
 
-func TestExcludeDebugName(t *testing.T) {
+func TestExclude_DebugName(t *testing.T) {
 	testDebugName(t, (Exclude{}).DebugName(), "Exclude")
 }
 
-func TestExcludeExecute(t *testing.T) {
+func TestExclude_Execute(t *testing.T) {
 	testCases := []struct {
 		sourceFiles []string
 		targetFiles []string

--- a/pkg/features/filter/exclude_test.go
+++ b/pkg/features/filter/exclude_test.go
@@ -16,6 +16,10 @@ func TestExcludeIsEnabled(t *testing.T) {
 	}
 }
 
+func TestExcludeDebugName(t *testing.T) {
+	testDebugName(t, (Exclude{}).DebugName(), "Exclude")
+}
+
 func TestExcludeExecute(t *testing.T) {
 	testCases := []struct {
 		sourceFiles []string

--- a/pkg/features/filter/include_test.go
+++ b/pkg/features/filter/include_test.go
@@ -16,6 +16,10 @@ func TestIncludeIsEnabled(t *testing.T) {
 	}
 }
 
+func TestIncludeDebugName(t *testing.T) {
+	testDebugName(t, (Include{}).DebugName(), "Include")
+}
+
 func TestIncludeExecute(t *testing.T) {
 	testCases := []struct {
 		sourceFiles []string

--- a/pkg/features/filter/include_test.go
+++ b/pkg/features/filter/include_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestIncludeIsEnabled(t *testing.T) {
+func TestInclude_IsEnabled(t *testing.T) {
 	config := cli.Configuration{Include: []string{
 		"foo.*",
 	}}
@@ -16,11 +16,11 @@ func TestIncludeIsEnabled(t *testing.T) {
 	}
 }
 
-func TestIncludeDebugName(t *testing.T) {
+func TestInclude_DebugName(t *testing.T) {
 	testDebugName(t, (Include{}).DebugName(), "Include")
 }
 
-func TestIncludeExecute(t *testing.T) {
+func TestInclude_Execute(t *testing.T) {
 	testCases := []struct {
 		sourceFiles []string
 		targetFiles []string

--- a/pkg/features/filter/util_test.go
+++ b/pkg/features/filter/util_test.go
@@ -1,0 +1,11 @@
+package filter
+
+import (
+	"testing"
+)
+
+func testDebugName(t *testing.T, actual string, expected string) {
+	if actual != expected {
+		t.Fatalf("Expected debug name to be '%s' but got '%s' instead", expected, actual)
+	}
+}

--- a/pkg/features/output/logfile.go
+++ b/pkg/features/output/logfile.go
@@ -7,7 +7,11 @@ import (
 )
 
 // LogFile enables writing output to a log file
-type LogFile struct {
+type LogFile struct{}
+
+// DebugName returns the debuggable name
+func (l LogFile) DebugName() string {
+	return "LogFile"
 }
 
 // IsEnabled check if the logfile flag is enabled
@@ -23,9 +27,4 @@ func (l LogFile) Execute(c *cli.Configuration) error {
 
 	output.SetOutput(c.LogFilePath)
 	return nil
-}
-
-// DebugName returns the debuggable name
-func (l LogFile) DebugName() string {
-	return "LogFile"
 }

--- a/pkg/features/output/logfile_test.go
+++ b/pkg/features/output/logfile_test.go
@@ -12,6 +12,10 @@ func TestLogFileIsEnabled(t *testing.T) {
 	lf.IsEnabled(&cli.Configuration{LogFilePath: "/tmp/log"})
 }
 
+func TestLogFileDebugName(t *testing.T) {
+	testDebugName(t, (LogFile{}).DebugName(), "LogFile")
+}
+
 func TestLogFileExecute(t *testing.T) {
 	lf := LogFile{}
 	err := lf.Execute(&cli.Configuration{LogFilePath: "/tmp/log"})

--- a/pkg/features/output/logfile_test.go
+++ b/pkg/features/output/logfile_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 )
 
-func TestLogFileIsEnabled(t *testing.T) {
+func TestLogFile_IsEnabled(t *testing.T) {
 	lf := LogFile{}
 	lf.IsEnabled(&cli.Configuration{LogFilePath: "/tmp/log"})
 }
 
-func TestLogFileDebugName(t *testing.T) {
+func TestLogFile_DebugName(t *testing.T) {
 	testDebugName(t, (LogFile{}).DebugName(), "LogFile")
 }
 
-func TestLogFileExecute(t *testing.T) {
+func TestLogFile_Execute(t *testing.T) {
 	lf := LogFile{}
 	err := lf.Execute(&cli.Configuration{LogFilePath: "/tmp/log"})
 	if err != nil {

--- a/pkg/features/output/quiet_test.go
+++ b/pkg/features/output/quiet_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestQuietIsEnabled(t *testing.T) {
+func TestQuiet_IsEnabled(t *testing.T) {
 	conf := cli.Configuration{Quiet: true}
 	quiet := Quiet{}
 	if !quiet.IsEnabled(&conf) {
@@ -14,11 +14,11 @@ func TestQuietIsEnabled(t *testing.T) {
 	}
 }
 
-func TestQuietDebugName(t *testing.T) {
+func TestQuiet_DebugName(t *testing.T) {
 	testDebugName(t, (Quiet{}).DebugName(), "Quiet")
 }
 
-func TestQuietExecute(t *testing.T) {
+func TestQuiet_Execute(t *testing.T) {
 	_ = Quiet{}.Execute(nil)
 
 	if output.Level() != output.LevelSilence {

--- a/pkg/features/output/quiet_test.go
+++ b/pkg/features/output/quiet_test.go
@@ -14,6 +14,10 @@ func TestQuietIsEnabled(t *testing.T) {
 	}
 }
 
+func TestQuietDebugName(t *testing.T) {
+	testDebugName(t, (Quiet{}).DebugName(), "Quiet")
+}
+
 func TestQuietExecute(t *testing.T) {
 	_ = Quiet{}.Execute(nil)
 

--- a/pkg/features/output/util_test.go
+++ b/pkg/features/output/util_test.go
@@ -1,0 +1,11 @@
+package output
+
+import (
+	"testing"
+)
+
+func testDebugName(t *testing.T, actual string, expected string) {
+	if actual != expected {
+		t.Fatalf("Expected debug name to be '%s' but got '%s' instead", expected, actual)
+	}
+}

--- a/pkg/features/output/verbose_test.go
+++ b/pkg/features/output/verbose_test.go
@@ -14,6 +14,10 @@ func TestVerboseIsEnabled(t *testing.T) {
 	}
 }
 
+func TestVerboseDebugName(t *testing.T) {
+	testDebugName(t, (Verbose{}).DebugName(), "Verbose")
+}
+
 func TestVerboseExecute(t *testing.T) {
 	verbose := Verbose{}
 	if err := verbose.Execute(nil); err != nil {

--- a/pkg/features/output/verbose_test.go
+++ b/pkg/features/output/verbose_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestVerboseIsEnabled(t *testing.T) {
+func TestVerbose_IsEnabled(t *testing.T) {
 	verboseConfig := cli.Configuration{Verbose: true}
 	verbose := Verbose{}
 	if !verbose.IsEnabled(&verboseConfig) {
@@ -14,11 +14,11 @@ func TestVerboseIsEnabled(t *testing.T) {
 	}
 }
 
-func TestVerboseDebugName(t *testing.T) {
+func TestVerbose_DebugName(t *testing.T) {
 	testDebugName(t, (Verbose{}).DebugName(), "Verbose")
 }
 
-func TestVerboseExecute(t *testing.T) {
+func TestVerbose_Execute(t *testing.T) {
 	verbose := Verbose{}
 	if err := verbose.Execute(nil); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Closes #15

## Description
- Ignore own zip file from file set
- Improve test coverage by also covering `DebugName` on features
