### PR TITLE
fix(#37): Fix retarded windows paths

### DIFF
--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	flag "github.com/spf13/pflag"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // ErrMinimalParamsMissing states that the minimal arguments for the tool are not present, making it unprocessable
@@ -86,11 +88,27 @@ func (conf *Configuration) parseVarargs() error {
 	return nil
 }
 
+func cleanPath(path string, isRetardedPlatform bool) string {
+	if !isRetardedPlatform {
+		return filepath.Clean(path)
+	}
+
+	windowsPath := filepath.Clean(path)
+	properPath := strings.ReplaceAll(windowsPath, "\\", "/")
+	return properPath
+}
+
 // CleanPaths ensure that all directories and files in the file set have clean path names
 func (conf *Configuration) CleanPaths() {
+	var isRetardedPlatform bool
+	if runtime.GOOS == "windows" {
+		isRetardedPlatform = true
+	} else {
+		isRetardedPlatform = false
+	}
 	cleaned := make([]string, 0, len(conf.SourceFiles))
 	for _, f := range conf.SourceFiles {
-		cleaned = append(cleaned, filepath.Clean(f))
+		cleaned = append(cleaned, cleanPath(f, isRetardedPlatform))
 	}
 	conf.SourceFiles = cleaned
 }


### PR DESCRIPTION
As it turns out the Windows Explorer can show zip files when they are broken, other clients like 7Zip not.

So this adds a hacky workaround for my favorite platform.

Closes #37 
