### PR TITLE
Fix: deterministic-zip v5 always shows help message regardless of arguments

### DIFF
--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -90,7 +90,7 @@ func (conf *Configuration) defineFlags() {
 }
 
 func (conf *Configuration) parseVarargs() error {
-	remaining := flag.Args()
+	remaining := conf.flagSet.Args()
 	if len(remaining) < 2 {
 		return ErrMinimalParamsMissing
 	}


### PR DESCRIPTION
## Description

Thank you very much for developing such a useful tool.

I am using the latest version of `deterministic-zip` in our CI process.
Today, the CI failed, and I found that the upgraded `deterministic-zip` outputs the following help message:

```
deterministic-zip 5.0.0 (25-07-30_19:23:09) by Timo Reymann  
deterministic-zip [-options] [zipfile list]
```

I tried several patterns of arguments, but in all cases, the behavior was the same — it only displayed the help message.

I confirmed that version 4 works as expected.

From my code reading, it seems that the issue is caused by a misuse of the `pflag` package.
Specifically, `flag.Args()` is nil, and it should be `conf.flagSet.Args()`.

With my fix, it works correctly.

Could you please take a look at my fix?

