### PR TITLE
fix: [#74] Fix regression with help flag

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -146,6 +146,16 @@ func TestExecute_SmokeTest(t *testing.T) {
 			shouldExit: true,
 		},
 		{
+			name:       "help shorthand flag should exit cleanly",
+			args:       []string{"program", "-h"},
+			shouldExit: true,
+		},
+		{
+			name:       "help long flag should exit cleanly",
+			args:       []string{"program", "--help"},
+			shouldExit: true,
+		},
+		{
 			name:       "zip file should be created",
 			args:       []string{"program", archiveName, "test_data/foo"},
 			shouldExit: false,

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -86,7 +86,6 @@ func (conf *Configuration) defineFlags() {
 	conf.addStringFlag(&conf.CompressionMethod, "compression-method", "Z", "deflate", "Set the default compression method. \nCurrently the main methods supported by zip are store and deflate. \nCompression method can be set to:\n\nstore       Setting the compression method to store forces to store entries with no compression. \n            This is generally faster than compressing entries, but results in no space savings.\n\ndeflate     This is the default method for zip. If zip determines that storing is better than deflation, the entry will be stored instead.\n")
 	conf.addStringFlag(&conf.LogFilePath, "logfile-path", "", "", "Open a logfile at the given path.\nBy default any existing file at that location is overwritten, but the --log-append option will result in an existing file being opened and the new log information appended to any existing information.")
 	conf.addBoolFlag(&conf.LogFileAppend, "log-append", "", false, "Append to existing logfile. Default is to overwrite.")
-	conf.flagSet.BoolP("Help", "h", false, "Show available commands")
 }
 
 func (conf *Configuration) parseVarargs() error {
@@ -126,7 +125,7 @@ func (conf *Configuration) CleanPaths() {
 func (conf *Configuration) Help() {
 	PrintCompactInfo()
 	println("deterministic-zip [-options] [zipfile list]")
-	flag.PrintDefaults()
+	conf.flagSet.PrintDefaults()
 }
 
 func (conf *Configuration) parseModifiedDate() (*time.Time, error) {
@@ -148,9 +147,10 @@ func (conf *Configuration) Parse() error {
 	conf.defineFlags()
 
 	isVersion := conf.flagSet.Bool("version", false, "Show version info")
+	isHelp := conf.flagSet.BoolP("Help", "h", false, "Show available commands")
 	err := conf.flagSet.Parse(os.Args[1:])
 
-	if errors.Is(err, flag.ErrHelp) {
+	if errors.Is(err, flag.ErrHelp) || (isHelp != nil && *isHelp) {
 		conf.Help()
 		return ErrAbort
 	} else if *isVersion {

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -57,6 +57,9 @@ type Configuration struct {
 	modifiedDate time.Time
 
 	flagSet *flag.FlagSet
+
+	isVersionCMD bool
+	isHelpCMD    bool
 }
 
 func (conf *Configuration) addBoolFlag(field *bool, long string, short string, val bool, usage string) {
@@ -86,6 +89,8 @@ func (conf *Configuration) defineFlags() {
 	conf.addStringFlag(&conf.CompressionMethod, "compression-method", "Z", "deflate", "Set the default compression method. \nCurrently the main methods supported by zip are store and deflate. \nCompression method can be set to:\n\nstore       Setting the compression method to store forces to store entries with no compression. \n            This is generally faster than compressing entries, but results in no space savings.\n\ndeflate     This is the default method for zip. If zip determines that storing is better than deflation, the entry will be stored instead.\n")
 	conf.addStringFlag(&conf.LogFilePath, "logfile-path", "", "", "Open a logfile at the given path.\nBy default any existing file at that location is overwritten, but the --log-append option will result in an existing file being opened and the new log information appended to any existing information.")
 	conf.addBoolFlag(&conf.LogFileAppend, "log-append", "", false, "Append to existing logfile. Default is to overwrite.")
+	conf.addBoolFlag(&conf.isVersionCMD, "version", "", false, "Show version info")
+	conf.addBoolFlag(&conf.isHelpCMD, "Help", "h", false, "Show available commands")
 }
 
 func (conf *Configuration) parseVarargs() error {
@@ -144,16 +149,12 @@ func (conf *Configuration) parseModifiedDate() (*time.Time, error) {
 
 // Parse the configuration from cli args
 func (conf *Configuration) Parse() error {
-	conf.defineFlags()
-
-	isVersion := conf.flagSet.Bool("version", false, "Show version info")
-	isHelp := conf.flagSet.BoolP("Help", "h", false, "Show available commands")
 	err := conf.flagSet.Parse(os.Args[1:])
 
-	if errors.Is(err, flag.ErrHelp) || (isHelp != nil && *isHelp) {
+	if errors.Is(err, flag.ErrHelp) || conf.isHelpCMD {
 		conf.Help()
 		return ErrAbort
-	} else if *isVersion {
+	} else if conf.isVersionCMD {
 		PrintVersionInfo()
 		return ErrAbort
 	}
@@ -176,5 +177,7 @@ func (conf *Configuration) ModifiedDate() time.Time {
 
 // NewConfiguration creates a new configuration
 func NewConfiguration() *Configuration {
-	return &Configuration{}
+	c := &Configuration{}
+	c.defineFlags()
+	return c
 }

--- a/pkg/cli/configuration_test.go
+++ b/pkg/cli/configuration_test.go
@@ -82,14 +82,7 @@ func TestCleanPaths(t *testing.T) {
 
 func TestConfiguration_Help_SmokeTest(t *testing.T) {
 	// Create a Configuration instance
-	config := &Configuration{}
-
-	// Test that Help() doesn't panic or fail
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Configuration.Help() panicked: %v", r)
-		}
-	}()
+	config := NewConfiguration()
 
 	// Call Help method - should not fail
 	config.Help()
@@ -100,7 +93,7 @@ func TestConfiguration_Help_SmokeTest(t *testing.T) {
 
 // TestConfiguration_Parse_HelpFlag tests Parse with help flag
 func TestConfiguration_Parse_HelpFlag(t *testing.T) {
-	config := &Configuration{}
+	config := NewConfiguration()
 
 	testCases := []struct {
 		name string
@@ -126,13 +119,6 @@ func TestConfiguration_Parse_HelpFlag(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test that Parse doesn't panic with help flags
-			defer func() {
-				if r := recover(); r != nil {
-					t.Errorf("Configuration.Parse() with help flag panicked: %v", r)
-				}
-			}()
-
 			// Save original os.Args and restore after test
 			originalArgs := os.Args
 			defer func() { os.Args = originalArgs }()
@@ -150,16 +136,12 @@ func TestConfiguration_Parse_HelpFlag(t *testing.T) {
 
 // TestConfiguration_Parse_VersionFlag tests Parse with version flag
 func TestConfiguration_Parse_VersionFlag(t *testing.T) {
-	config := &Configuration{}
+	config := NewConfiguration()
 
 	testCases := []struct {
 		name string
 		args []string
 	}{
-		{
-			name: "short version flag",
-			args: []string{"program", "-v"},
-		},
 		{
 			name: "long version flag",
 			args: []string{"program", "--version"},
@@ -176,12 +158,6 @@ func TestConfiguration_Parse_VersionFlag(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test that Parse doesn't panic with version flags
-			defer func() {
-				if r := recover(); r != nil {
-					t.Errorf("Configuration.Parse() with version flag panicked: %v", r)
-				}
-			}()
 
 			// Save original os.Args and restore after test
 			originalArgs := os.Args
@@ -200,7 +176,7 @@ func TestConfiguration_Parse_VersionFlag(t *testing.T) {
 
 // TestConfiguration_Parse_HelpAndVersionFlags tests Parse with both help and version flags
 func TestConfiguration_Parse_HelpAndVersionFlags(t *testing.T) {
-	config := &Configuration{}
+	config := NewConfiguration()
 
 	testCases := []struct {
 		name string
@@ -246,14 +222,7 @@ func TestConfiguration_Parse_HelpAndVersionFlags(t *testing.T) {
 
 // TestConfiguration_Parse_EmptyArgs tests Parse with no arguments
 func TestConfiguration_Parse_EmptyArgs(t *testing.T) {
-	config := &Configuration{}
-
-	// Test that Parse doesn't panic with empty args
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Configuration.Parse() with empty args panicked: %v", r)
-		}
-	}()
+	config := NewConfiguration()
 
 	// Save original os.Args and restore after test
 	originalArgs := os.Args
@@ -270,7 +239,7 @@ func TestConfiguration_Parse_EmptyArgs(t *testing.T) {
 
 // TestConfiguration_Parse_InvalidHelpVariations tests Parse with invalid help flag variations
 func TestConfiguration_Parse_InvalidHelpVariations(t *testing.T) {
-	config := &Configuration{}
+	config := NewConfiguration()
 
 	testCases := []struct {
 		name string
@@ -333,8 +302,8 @@ func TestConfiguration_Parse_MultipleInstances(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test multiple Configuration instances
-			config1 := &Configuration{}
-			config2 := &Configuration{}
+			config1 := NewConfiguration()
+			config2 := NewConfiguration()
 
 			defer func() {
 				if r := recover(); r != nil {


### PR DESCRIPTION
- Re-enable the `-h` shorthand flag for help
- Fix help usage output by using the local flagset
- Move flagset definition from parse to factory method