### PR TITLE
feat: Add -j/--junk-paths flag to strip directory paths

### DIFF
--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -42,6 +42,9 @@ type Configuration struct {
 	// Include patterns
 	Include []string
 
+	// JunkPaths strips directory paths from archived files, storing only the filename
+	JunkPaths bool
+
 	// CompressionMethod to use for the zip archive
 	CompressionMethod string
 
@@ -85,6 +88,7 @@ func (conf *Configuration) defineFlags() {
 	conf.addBoolFlag(&conf.Verbose, "verbose", "v", false, "Verbose mode or print diagnostic version info.")
 	conf.addBoolFlag(&conf.Directories, "directories", "D", false, "Include directories in the zip file.")
 	conf.addBoolFlag(&conf.Recursive, "recurse-paths", "r", false, "Include all files verbose")
+	conf.addBoolFlag(&conf.JunkPaths, "junk-paths", "j", false, "Store just the name of a saved file (junk the path), and do not store directory names. By default, deterministic-zip will store the full path (relative to the current directory).")
 	conf.addBoolFlag(&conf.Quiet, "quiet", "q", false, "Quiet mode; eliminate informational messages")
 	conf.addStringsFlag(&conf.Exclude, "exclude", "x", []string{}, "Exclude specific file patterns")
 	conf.addStringsFlag(&conf.Include, "include", "i", []string{}, "Include only the specified file pattern")

--- a/pkg/zip/main.go
+++ b/pkg/zip/main.go
@@ -42,7 +42,7 @@ func Create(c *cli.Configuration, compression uint16) error {
 
 	sort.Strings(c.SourceFiles)
 	for _, srcFile := range c.SourceFiles {
-		if err := appendFile(srcFile, zipWriter, compression, c.ModifiedDate(), conditions.OnFlag(c.Directories)); err != nil {
+		if err := appendFile(srcFile, zipWriter, compression, c.ModifiedDate(), conditions.OnFlag(c.Directories), c.JunkPaths); err != nil {
 			return err
 		}
 	}
@@ -56,7 +56,7 @@ func registerCompressors(zipWriter *zip.Writer) {
 	})
 }
 
-func appendFile(srcFile string, zipWriter *zip.Writer, compression uint16, modifiedTimestamp time.Time, includeDirs bool) error {
+func appendFile(srcFile string, zipWriter *zip.Writer, compression uint16, modifiedTimestamp time.Time, includeDirs bool, junkPaths bool) error {
 	output.Infof("Adding %s", srcFile)
 
 	f, err := os.Open(srcFile)
@@ -77,6 +77,10 @@ func appendFile(srcFile string, zipWriter *zip.Writer, compression uint16, modif
 		return err
 	}
 
+	if junkPaths && stat.IsDir() {
+		return nil
+	}
+
 	if !includeDirs && stat.IsDir() {
 		return nil
 	}
@@ -87,7 +91,11 @@ func appendFile(srcFile string, zipWriter *zip.Writer, compression uint16, modif
 	}
 	h.Modified = modifiedTimestamp
 	h.Method = compression
-	h.Name = srcFile
+	if junkPaths {
+		h.Name = filepath.Base(srcFile)
+	} else {
+		h.Name = srcFile
+	}
 	h.Extra = extra
 
 	// If dealing with a directory, we must ensure the h.Name field ends with a `/`

--- a/pkg/zip/main_test.go
+++ b/pkg/zip/main_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -80,6 +82,39 @@ func TestCreate(t *testing.T) {
 			zipFiles: []expectedFile{
 				{
 					name: "testdata/folder/file.txt",
+				},
+			},
+		},
+		{
+			config: cli.Configuration{
+				SourceFiles: []string{
+					"testdata/folder/file.txt",
+				},
+				JunkPaths: true,
+			},
+			sha256:      "placeholder",
+			compression: zip.Store,
+			zipFiles: []expectedFile{
+				{
+					name: "file.txt",
+				},
+			},
+		},
+		{
+			config: cli.Configuration{
+				Directories: true,
+				JunkPaths:   true,
+				SourceFiles: []string{
+					"testdata",
+					"testdata/folder",
+					"testdata/folder/file.txt",
+				},
+			},
+			sha256:      "placeholder",
+			compression: zip.Store,
+			zipFiles: []expectedFile{
+				{
+					name: "file.txt",
 				},
 			},
 		},
@@ -325,4 +360,87 @@ func createTmpFile() string {
 	_ = f.Close()
 	_ = os.Remove(f.Name())
 	return f.Name()
+}
+
+func TestCreate_DeterministicJunkPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sourceNames := []string{
+		filepath.Join(tmpDir, "alpha", "doc.txt"),
+		filepath.Join(tmpDir, "beta", "nested", "notes.md"),
+		filepath.Join(tmpDir, "data.csv"),
+	}
+	expectedNames := []string{"doc.txt", "notes.md", "data.csv"}
+
+	for _, src := range sourceNames {
+		if err := os.MkdirAll(filepath.Dir(src), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(src, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var lastChecksum string
+	for i := 0; i < 20; i++ {
+		shuffled := make([]string, len(sourceNames))
+		copy(shuffled, sourceNames)
+		rand.Shuffle(len(shuffled), func(i, j int) {
+			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		})
+
+		config := cli.Configuration{
+			SourceFiles: shuffled,
+			JunkPaths:   true,
+		}
+
+		tmpFile := createTmpFile()
+		tmpZip := tmpFile + ".zip"
+		config.ZipFile = tmpZip
+
+		if err := Create(&config, zip.Store); err != nil {
+			t.Fatal(err)
+		}
+
+		sha := checksum(tmpZip)
+		if i == 0 {
+			lastChecksum = sha
+		} else if sha != lastChecksum {
+			t.Fatalf("Run #%d: checksum mismatch: expected %s, got %s", i, lastChecksum, sha)
+		}
+
+		r, err := zip.OpenReader(tmpZip)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(r.File) != len(expectedNames) {
+			r.Close()
+			t.Fatalf("Expected %d entries, got %d", len(expectedNames), len(r.File))
+		}
+
+		for _, zf := range r.File {
+			if strings.Contains(zf.Name, "/") {
+				r.Close()
+				t.Fatalf("Expected basename only, got: %s", zf.Name)
+			}
+		}
+
+		for _, expectedName := range expectedNames {
+			found := false
+			for _, zf := range r.File {
+				if zf.Name == expectedName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				r.Close()
+				t.Fatalf("Expected file %s to be in archive", expectedName)
+			}
+		}
+
+		r.Close()
+		os.Remove(tmpZip)
+	}
 }


### PR DESCRIPTION
## Description

Adds the `-j` / `--junk-paths` flag matching the behavior of the original `zip` command. When enabled, only the basename of each file is stored in the archive and directory entries are excluded.

Closes #100

## Changes

- **pkg/cli/configuration.go**: Added `JunkPaths bool` field and `-j`/ `--junk-paths` flag
- **pkg/zip/main.go**: When `junkPaths` is true, skip directories and use `filepath.Base(srcFile)` for the zip entry name
- **pkg/zip/main_test.go**: Added test cases for junk-paths behavior and a dedicated determinism test

## Verification

```
$ go test ./...
$ go run . -j /tmp/test.zip path/to/file.txt
$ unzip -l /tmp/test.zip
# Shows just file.txt instead of path/to/file.txt
```